### PR TITLE
Added serial port IO based on interrupts instead of polling

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -49,7 +49,7 @@ Screen.prototype.returnOrClear = function (){
     this.startChar()
     this.cursor[0] = 0
   } else {
-    this.returnChar()
+    this.newline()
   }
 }
 


### PR DESCRIPTION
So I got serial port IO working based on interrupts. On my machine I wasn't able to get data to send from the console into qemu, but I could go from qemu to the console. It did work by setting up qemu as a telnet server. Not sure if its my setup or just how qemu serial port redirection works.

Outbound data is queued until `Enter` is pressed. Inbound data is displayed as its received. 

To use telnet I had to modify the runtime-playground.js

I used `-serial telnet:localhost:9999,server` instead of `-serial stdio`

Here are some helpful links I used to figure out how this all needed to work.
 http://www.lammertbies.nl/comm/info/serial-uart.html#FCR
 http://flint.cs.yale.edu/cs422/doc/art-of-asm/pdf/CH22.PDF
 http://wiki.osdev.org/PIC
